### PR TITLE
Fixes illogic result convention when reference flow of a line in PowSyBl is negative

### DIFF
--- a/src/main/java/com/farao_community/farao/flow_decomposition/FlowDecompositionComputer.java
+++ b/src/main/java/com/farao_community/farao/flow_decomposition/FlowDecompositionComputer.java
@@ -174,7 +174,9 @@ public class FlowDecompositionComputer {
         SparseMatrixWithIndexesTriplet ptdfMatrixTriplet = new SparseMatrixWithIndexesTriplet(xnecIndex, nodeIndex, factors.size() + 1);
         for (SensitivityValue sensitivityValue : sensiResult.getValues()) {
             SensitivityFactor factor = factors.get(sensitivityValue.getFactorIndex());
-            ptdfMatrixTriplet.addItem(factor.getFunctionId(), factor.getVariableId(), sensitivityValue.getValue());
+            double sensitivity = sensitivityValue.getValue();
+            double referenceOrientedSensitivity = sensitivityValue.getFunctionReference() < 0 ? -sensitivity : sensitivity;
+            ptdfMatrixTriplet.addItem(factor.getFunctionId(), factor.getVariableId(), referenceOrientedSensitivity);
         }
         return ptdfMatrixTriplet;
     }

--- a/src/test/java/com/farao_community/farao/flow_decomposition/AllocatedFlowTests.java
+++ b/src/test/java/com/farao_community/farao/flow_decomposition/AllocatedFlowTests.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
  * @author Hugo Schindler {@literal <hugo.schindler at rte-france.com>}
  */
-
 class AllocatedFlowTests {
     private static final double EPSILON = 1e-3;
 
@@ -35,6 +34,42 @@ class AllocatedFlowTests {
         String loadBe = "BLOAD 11_load";
         String genFr = "FGEN1 11_generator";
         String xnecFrBee = "FGEN1 11 BLOAD 11 1";
+        String allocated = "Allocated";
+
+        Network network = importNetwork(networkFileName);
+        FlowDecompositionComputer allocatedFlowComputer = new FlowDecompositionComputer();
+        FlowDecompositionResults flowDecompositionResults = allocatedFlowComputer.run(network, true);
+
+        Map<String, DecomposedFlow> decomposedFlowMap = flowDecompositionResults.getDecomposedFlowsMap();
+        assertEquals(100, decomposedFlowMap.get(xnecFrBee).getAllocatedFlow(), EPSILON);
+
+        var optionalGlsks = flowDecompositionResults.getGlsks();
+        assertTrue(optionalGlsks.isPresent());
+        var glsks = optionalGlsks.get();
+        assertEquals(1.0, glsks.get(Country.FR).get(genFr), EPSILON);
+        assertEquals(1.0, glsks.get(Country.BE).get(genBe), EPSILON);
+
+        var optionalPtdfs = flowDecompositionResults.getPtdfMap();
+        assertTrue(optionalPtdfs.isPresent());
+        var ptdfs = optionalPtdfs.get();
+        assertEquals(-0.5, ptdfs.get(xnecFrBee).get(loadBe));
+        assertEquals(-0.5, ptdfs.get(xnecFrBee).get(genBe));
+        assertEquals(+0.5, ptdfs.get(xnecFrBee).get(genFr));
+
+        var optionalNodalInjections = flowDecompositionResults.getNodalInjectionsMap();
+        assertTrue(optionalNodalInjections.isPresent());
+        var nodalInjections = optionalNodalInjections.get();
+        assertEquals(-100, nodalInjections.get(genBe).get(allocated));
+        assertEquals(+100, nodalInjections.get(genFr).get(allocated));
+    }
+
+    @Test
+    void checkThatAllocatedFlowAreExtractedForEachXnecGivenABasicNetworkWithInvertedConvention() {
+        String networkFileName = "NETWORK_SINGLE_LOAD_TWO_GENERATORS_WITH_COUNTRIES_INVERTED.uct";
+        String genBe = "BGEN2 11_generator";
+        String loadBe = "BLOAD 11_load";
+        String genFr = "FGEN1 11_generator";
+        String xnecFrBee = "BLOAD 11 FGEN1 11 1";
         String allocated = "Allocated";
 
         Network network = importNetwork(networkFileName);

--- a/src/test/resources/com/farao_community/farao/flow_decomposition/NETWORK_SINGLE_LOAD_TWO_GENERATORS_WITH_COUNTRIES_INVERTED.uct
+++ b/src/test/resources/com/farao_community/farao/flow_decomposition/NETWORK_SINGLE_LOAD_TWO_GENERATORS_WITH_COUNTRIES_INVERTED.uct
@@ -1,0 +1,17 @@
+##C 2007.05.01
+This is a test network with only two branches.
+Each branch is linking a generator with a  central load.
+Used to validate:
+- Basic network importer
+- XNEC automatic selection
+- GLSK automatic generation
+- Zone automatic extraction
+##N
+##ZFR
+FGEN1 11 GEN          0 3 400.00 0.00000 0.00000 -100.00 0.00000 1000.00 -1000.0 1000.00 -1000.0
+##ZBE
+BGEN2 11 GEN          0 2 400.00 0.00000 0.00000 -100.00 0.00000 1000.00 -1000.0 1000.00 -1000.0
+BLOAD 11 LOAD         0 0        200.000 0.00000 0.00000 0.00000
+##L
+BLOAD 11 FGEN1 11 1 0 1.0000 0.0500 0.000000    480 LINE
+BLOAD 11 BGEN2 11 1 0 1.0000 0.0500 0.000000    480 LINE


### PR DESCRIPTION
Fixes illogic result convention when reference flow of a line in PowSyBl is negative (flow from side 2 to side 1 of the line)

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Current beahviour is that when a line flow in the network is from side 2 to side 1 ("negative flow"), then allocated flow are also expressed in the same convention (relatively to the 1->2 flow and not in the orientation of actual flow on the line.


**What is the new behavior (if this is a feature change)?**
Allocated flow is expressed in the actual flow orientation convention.

